### PR TITLE
framework macros: mark generated functions as pub

### DIFF
--- a/crates/robespierre-fw-macros/src/lib.rs
+++ b/crates/robespierre-fw-macros/src/lib.rs
@@ -25,7 +25,7 @@ pub fn command(
     let result = quote! {
         #command_func
 
-        fn #old_name <'a> (
+        pub fn #old_name <'a> (
             ctx: &'a ::robespierre::framework::standard::FwContext,
             message: &'a ::robespierre_models::channel::Message,
             args: &'a str,


### PR DESCRIPTION
I'm working on a Revolt bot and one of the things that's getting in
the way of my code organization is the lack of being able to put commands
into their own modules. This patch will let you do that.