### PR TITLE
Trust & safety team in user badges

### DIFF
--- a/crates/robespierre-models/src/users.rs
+++ b/crates/robespierre-models/src/users.rs
@@ -83,7 +83,7 @@ bitflags! {
         const TRANSLATOR = 2;
         const SUPPORTER = 4;
         const RESPONSIBLE_DISCLOSURE = 8;
-        const REVOLT_TEAM = 16;
+        const TRUST_SAFETY_STAFF = 16;
         const EARLY_ADOPTER = 256;
     }
 }


### PR DESCRIPTION
As per https://github.com/revoltchat/api/pull/5, rename `REVOLT_TEAM` to `TRUST_SAFETY_STAFF` in `robespierre_models::users::Badges`.